### PR TITLE
docs: course-design-sources — bronnen pool voor training-ontwerp

### DIFF
--- a/docs/course-design-sources.md
+++ b/docs/course-design-sources.md
@@ -1,0 +1,30 @@
+# Course design — bronnen pool
+
+Overzicht van bronnen die meegenomen moeten worden bij het ontwerpen van BeeHaive trainingen (cursussen in ontwikkeling).
+
+## Getagde clippings
+
+Alle bronnen met `project.beehaive.building-blocks: [knowledge]` in de frontmatter. Getagd op 2026-04-18 (26 clippings):
+
+- 19 clippings in `~/ODIN/resources/bronnen/onderwijs/` (bron-002 t/m bron-020) — PBL, leerwetenschap, NLP, blended learning
+- 7 clippings in `~/ODIN/resources/bronnen/ai/` (bron-099 t/m bron-105) — AI in onderwijs, AI ethics training, custom GPTs, agentic AI foundations
+
+**Query voor opvragen:**
+```bash
+grep -rl 'beehaive:' ~/ODIN/resources/bronnen/ --include='*.md'
+```
+
+## Extra meenemen (niet getagd, wél relevant)
+
+Deze twee bronnen zijn bewust niet getagd (ze zijn strikt geen clippings), maar horen inhoudelijk bij dezelfde course-methodology pool:
+
+- `~/ODIN/resources/bronnen/onderwijs/bron-001-architectuur-transformatieve-educatie.md` — kennis-synthese over transformatieve educatie
+- `~/ODIN/resources/bronnen/onderwijs/bron-021-key-principles-for-pbl-white-paper.md` — PDF white paper over PBL
+
+## Gebruik bij course design
+
+Wanneer BeeHaive course design start: draai een combined query — getagde clippings + de twee expliciete paden hierboven — voordat je de bronnen-scope vaststelt. De tagging alleen mist bron-001 en bron-021.
+
+## Herkomst
+
+Vastgelegd 2026-04-19. Taggingbeslissing en scope toegelicht in de ccf sessie van 2026-04-18.


### PR DESCRIPTION
## Summary

- Nieuw `docs/course-design-sources.md`: overzicht van bronnen die bij BeeHaive course design meegenomen moeten worden
- Getagde clippings via `project.beehaive.building-blocks:knowledge` in `resources/bronnen/onderwijs/` + `ai/` (26 clippings getagd 2026-04-18)
- Twee expliciete extra bronnen: `bron-001-architectuur-transformatieve-educatie.md` en `bron-021-key-principles-for-pbl-white-paper.md`
- Verhuist inhoud uit een global memory-file naar project-docs — voorkomt ruis in andere project-contexten (ccf/hqo/aia)

## Context

Uit analyse van [bron-110 "16 Second Brain Practices for Solo Operators"](https://substack.jurgenappelo.com/p/16-second-brain-practices) in het ccf-framework. Simplify-reviewer flagde dat project-specifieke kennis in global memory de verkeerde laag was.

## Test plan

- [ ] Verifieer dat `docs/course-design-sources.md` correct rendert
- [ ] Check dat linked paden kloppen (bron-001, bron-021 bestaan in ~/ODIN/resources/bronnen/onderwijs/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)