### PR TITLE
docs: training-design onderzoek — didactiek + retentie/AI-tutor

### DIFF
--- a/docs/research/training-design-2026-04/01-didactiek-pbl.md
+++ b/docs/research/training-design-2026-04/01-didactiek-pbl.md
@@ -1,0 +1,39 @@
+# 01 — Didactiek: project-based learning & andragogiek
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Kernbevindingen
+
+**Andragogiek (Knowles) is nog steeds het fundament.** Knowles' zes uitgangspunten — (1) need to know, (2) zelfconcept, (3) eerdere ervaring, (4) readiness, (5) orientation to learning (problem-centered, niet content-centered) en (6) intrinsieke motivatie — zijn in recent werk (2024–2025) niet weerlegd, wel gerelativeerd: ze fungeren meer als ontwerpprincipes dan als geteste theorie. Clair (2024) in *New Directions for Adult and Continuing Education* en de CDC-samenvatting (2024) bevestigen dat de principes breed worden toegepast in management, gezondheidszorg en onderwijs. Meta-analytische evidentie specifiek voor de zes principes als geheel ontbreekt; de principes werken *als* je ze vertaalt naar concrete designkeuzes zoals hieronder.
+
+**Project-based learning (PBL) is goed onderbouwd voor professionals.** Over meerdere meta-analyses en reviews heen rapporteren PBL-cohorten hogere toepassing en transfer, betere retentie, en hogere motivatie dan lecture-only formats. Voor professionals werkt het extra goed omdat zij leren vanuit intrinsieke, doelgerichte motivatie (probleem uit eigen werkcontext).
+
+**Structuur is essentieel: "open-ended" zonder scaffolding werkt niet.** Onderzoek (IES; Boardman 2025; Framework for Scaffolding 2013, meta-analyse 2023) toont consistent dat PBL faalt zonder:
+
+- **Scaffolds**: voorgestructureerde templates, checkpoints, worked examples per bouwsteen. Voor BeeHaive: een "project canvas" per bouwsteen/guardrail.
+- **Check-ins**: wekelijkse sync-momenten, korte 1-op-1 of kleine subgroepen van 3–5.
+- **Peer review met structuur**: ongestructureerde peer feedback is slecht; gestructureerde rubric-based peer review (zoals SWoRD) verbetert zowel de reviewer als de ontvanger.
+
+**Verhouding theorie:praktijk.** Het populaire 70:20:10-model (70% on-the-job, 20% sociaal, 10% formeel) is *géén* evidence-based recept — het komt uit self-reports van 200 executives (Lombardo, Eichinger, McCall jaren '80). Training Industry, CCL en Tandfonline-onderzoek (2021) wijzen er expliciet op: gebruik het als *intuïtieve verdeelsleutel*, niet als wet. Voor een blended AI-governance training is een verhouding van **ongeveer 30% theorie / 70% toepassing** in de contacturen realistisch, met theorie vooral self-paced (flipped).
+
+## Design-implicaties voor BeeHaive
+
+- Elke cursist start dag 1 met een **eigen governance-vraagstuk uit eigen organisatie** (intrinsieke motivatie; Knowles).
+- Per bouwsteen/guardrail: worked example → eigen toepassing → peer review → coach/AI-bot feedback.
+- Check-ins wekelijks; synchroon kort (45–60 min); peer review met expliciete rubric.
+
+## Bronnen
+
+- [Andragogy: Past and Present Potential — Clair (2024)](https://onlinelibrary.wiley.com/doi/full/10.1002/ace.20546)
+- [CDC: Adult Learning Principles (2024)](https://www.cdc.gov/training-development/media/pdfs/2024/04/adult-learning-principles.pdf)
+- [Andragogy in Practice — PMC (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11008574/)
+- [JFF Adult Learners Literature Review (Feb 2025)](https://www.jff.org/wp-content/uploads/2025/02/Adult-Learner-Full-Final-Report-2.20.25.pdf)
+- [PBL Framework — Nature Scientific Reports (2025)](https://www.nature.com/articles/s41598-025-10385-4)
+- [PBLWorks Research](https://www.pblworks.org/research)
+- [Almulla — PBL Effectiveness (Sage Open)](https://journals.sagepub.com/doi/10.1177/2158244020938702)
+- [Framework for Designing Scaffolds — PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC3827669/)
+- [Regulated Learning Scaffolding Meta-analysis — PMC (2023)](https://pmc.ncbi.nlm.nih.gov/articles/PMC10075206/)
+- [IES: Intelligent Scaffolding for Peer Reviews](https://ies.ed.gov/use-work/awards/intelligent-scaffolding-peer-reviews-writing)
+- [70:20:10 Where is the Evidence? — ATD](https://www.td.org/content/atd-blog/70-20-10-where-is-the-evidence)
+- [70:20:10 Debate — Tandfonline (2021)](https://www.tandfonline.com/doi/full/10.1080/09540962.2021.1951517)
+- [Training Industry — 70:20:10](https://trainingindustry.com/wiki/content-development/the-702010-model-for-learning-and-development/)

--- a/docs/research/training-design-2026-04/02-didactiek-multimodaal.md
+++ b/docs/research/training-design-2026-04/02-didactiek-multimodaal.md
@@ -1,0 +1,83 @@
+# 02 — Didactiek: multimodaliteit & materialenmix
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Kernbevinding: VAK/leerstijlen is een neuromyth
+
+Dit moet expliciet en respectvol worden geadresseerd. De wetenschappelijke consensus is helder:
+
+- **Pashler et al. (2008)**: geen empirische steun voor de "meshing hypothesis" — het idee dat matching van instructie aan een voorkeursstijl tot beter leren leidt.
+- **Newton (2015, Frontiers in Psychology)**: 89% van recente hoger-onderwijs-publicaties ondersteunt VAK *ondanks* afwezigheid van bewijs. 93% van docenten gelooft in leerstijlen. Dit is precies waarom de myth hardnekkig blijft (confirmation bias + intuïtieve aantrekkelijkheid).
+- **Frontiers meta-analyse (2024)**: na aggregatie van studies is er *nog steeds* geen meetbaar effect van het matchen van instructie aan voorkeursstijl.
+- **Frontiers (2021)** bevestigt dat de myth ook in medisch onderwijs "thriving" is.
+
+Mensen hebben **voorkeuren** (ik hoor graag een podcast tijdens het lopen) — dat betekent **niet** dat ze ook daadwerkelijk beter leren in die modaliteit voor willekeurig materiaal. Een instructie voor het monteren van een kast leert iedereen beter met beeld + tekst, ongeacht "stijl".
+
+## Wat wél werkt: dual coding + multimedia learning
+
+De multimodale mix is **wel verdedigbaar**, maar om ándere, sterkere redenen:
+
+**Dual Coding Theory (Paivio 1971; Clark & Paivio 1991; recent bevestigd):**
+
+- Informatie die gelijktijdig via verbaal én visueel kanaal wordt gecodeerd, krijgt twee retrieval-cues → significant betere recall (picture superiority effect).
+- Recente retentiestudies (2024) laten zien dat dual-coded lessen de vergeetcurve afvlakken.
+
+**Mayer's Cognitive Theory of Multimedia Learning (12 principes, editie 2021, >200 experimenten):**
+
+1. **Coherence** — verwijder irrelevant beeld/muziek/tekst.
+2. **Signaling** — markeer kernpunten visueel.
+3. **Redundancy** — géén woord-voor-woord ondertiteling + narratie (overbelast).
+4. **Spatial contiguity** — plaats label náást het ding.
+5. **Temporal contiguity** — beeld en spraak gelijktijdig.
+6. **Segmenting** — deel instructie op in user-paced chunks.
+7. **Pre-training** — introduceer begrippen vooraf.
+8. **Modality** — spreek tekst uit, toon beeld (niet tekst-op-tekst).
+9. **Multimedia** — beeld + woorden > alleen woorden.
+10. **Personalization** — conversational tone ("jij" i.p.v. formeel).
+11. **Voice** — menselijke stem > synthetische stem (nuance: moderne TTS kleiner verschil).
+12. **Image** — pratend hoofd is optioneel; voegt niet altijd toe.
+
+### Eerlijke framing richting de opdrachtgever
+
+> "We leveren de multimodale mix die je wilt — tekst, audio, video, infographics — maar het werkt niet omdat 'sommigen auditieve leerders zijn'. Het werkt omdat (a) variatie cognitive load verlaagt, (b) herhaling via een ander kanaal de retrieval cues verdubbelt (dual coding), (c) toegankelijkheid verhoogt voor wie tijdelijk in de auto, achter laptop of met dyslexie leert, en (d) keuzevrijheid motivatie verhoogt. Het is dus effectief om stevigere redenen dan de neuromyth."
+
+## Materialenmix — welk format voor welke taak
+
+| Format | Wanneer het best werkt | Ontwerp-principes |
+|---|---|---|
+| **Long-form tekst** | Diepte, nuance, zelf-tempo, zoekbaar terugvinden. Bij complex, lang materiaal wint print/tekst op retentie en kritische analyse — mits de lezer vaardig is. | 1.500–4.000 woorden, duidelijke H2/H3-structuur, samenvattingsblokken, downloadbaar als PDF. |
+| **Flashcards / spaced repetition** | Feiten, definities, jargon, framework-componenten (7 bouwstenen, 7 guardrails = perfect materiaal). Sterkste evidence-based techniek; Rowland (2014) g=0.50; Adesope (2017) 217 studies. | Korte vraag → korte antwoord, één concept per kaart, Anki/Leitner-cadans (1-3-7-14 dagen). |
+| **Podcasts** | Commute, herhaling via ander kanaal, storytelling, interviews met praktijkcases. MDPI 2024: effectief voor intentional en incidental learning. | 15–30 min; 1 kernidee + 1–2 casus; niet de primaire theoriebron. |
+| **Infographics** | Overzicht, relaties, samenhang (framework-schema 7+7 is ideaal). PMC 2022: verhoogt engagement, retentie, recall — onderbouwd vanuit dual coding. | 1 boodschap per infographic; visueel hiërarchisch; wit-ruimte; scanbaar in <30s; staat ook los van tekst. |
+| **Video** | Demonstratie (AI-tool live), human connection, procedures. Guo/MIT-analyse van 6,9M MOOC-video-sessies: engagement zakt dramatisch ná 6 minuten. | **2–5 min** per video ideaal (microlearning); talking head optioneel (Mayer image-principle); script volgens coherence + signaling. |
+
+### Algemene designprincipes
+
+- **Productiekwaliteit-minimum**: heldere audio (cruciaal — publiek vergeeft wankele video, niet slechte audio), leesbare tekst, geen afleidende muziek onder spraak (coherence).
+- **Accessibility als kwaliteitsnorm**: transcripties voor video/podcast; alt-tekst bij infographics; leesniveau B1–B2 voor Nederlandstalige pro's (ook bij hbo+, want cognitive load).
+- **Redundantie is goed — maar in het juiste formaat**: dezelfde kern van een bouwsteen in tekst, in korte video, als flashcard, als infographic. Niet 4× dezelfde informatie, wél dezelfde kernboodschap in 4 modaliteiten. Dit is retrieval practice + dual coding, niet leerstijlen.
+
+## Bronnen
+
+**Leerstijlen-neuromyth**
+
+- [Newton (2015): Learning Styles Myth is Thriving — Frontiers in Psychology](https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2015.01908/full)
+- [Is it really a neuromyth? Meta-analysis — Frontiers (2024)](https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2024.1428732/full)
+- [Learning Styles Neuromyth in Medical Education — Frontiers (2021)](https://www.frontiersin.org/journals/human-neuroscience/articles/10.3389/fnhum.2021.708540/full)
+- [ATD: L&D Neuromyth — Learning Styles](https://www.td.org/content/atd-blog/l-d-neuromyth-learning-styles-visual-auditory-kinesthetic)
+
+**Dual Coding & Multimedia Learning**
+
+- [Clark & Paivio: Dual Coding and Education (Educational Psychology Review)](https://link.springer.com/article/10.1007/BF01320076)
+- [Mayer's 12 Principles — DLI](https://www.digitallearninginstitute.com/blog/mayers-principles-multimedia-learning)
+- [Mayer (2023): Past, Present, Future of CTML — Springer](https://link.springer.com/article/10.1007/s10648-023-09842-1)
+- [Multimedia Learning Best Practices — UC San Diego](https://multimedia.ucsd.edu/best-practices/multimedia-learning.html)
+
+**Formats: video, tekst, podcast, infographic**
+
+- [Optimal instructional video length — SUNY OSCQR](https://oscqr.suny.edu/how-long-should-instructional-videos-be/)
+- [Microlearning Systematic Review — Sciencedirect (2024)](https://www.sciencedirect.com/science/article/pii/S2405844024174440)
+- [Text vs Video — Sciencedirect (2020)](https://www.sciencedirect.com/science/article/abs/pii/S0360131520302323)
+- [Digital Texts & Videos — PMC (2022)](https://pmc.ncbi.nlm.nih.gov/articles/PMC9464432/)
+- [Infographics Design Principles — PMC (2022)](https://pmc.ncbi.nlm.nih.gov/articles/PMC9274103/)
+- [Podcasts & Informal Learning — MDPI (2024)](https://www.mdpi.com/2227-7102/14/10/1129)

--- a/docs/research/training-design-2026-04/03-didactiek-blended-pilot.md
+++ b/docs/research/training-design-2026-04/03-didactiek-blended-pilot.md
@@ -1,0 +1,94 @@
+# 03 — Didactiek: blended learning, pilot & meting (Kirkpatrick)
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Flipped classroom werkt
+
+Meta-analyses (Sciencedirect 2023, 2025; second-order meta-analyse): flipped classroom heeft consistent positief effect, gewogen effectgrootte g ≈ 0.58–0.73. Pedagogie > technologie. Model: theorie (video, tekst, podcast) vooraf zelf → live tijd besteden aan toepassen, vragen, peer feedback.
+
+## Cohort vs. self-paced: dramatisch verschil in completion
+
+| Format | Completion rate |
+|---|---|
+| Self-paced MOOC (Coursera, Udemy) | **3–15%** |
+| Cohort-based (Maven, Section, Reforge) | **75–88%** |
+
+Mechanisme: accountability, tijd-urgentie (start/einddatum), peer-zichtbaarheid, directe toegang tot docent. Voor BeeHaive is een cohort-format dus bijna een must — zeker in de pilotfase waarin je product-market fit wilt valideren.
+
+## Praktijkrichtlijnen synchrone sessies
+
+- **Duur**: 45–60 min optimaal; max 90 min met break. Langere Zoom-sessies leiden tot digitale vermoeidheid.
+- **Groepsgrootte**: 10 min – 20 max per live-groep (onder de 8 weinig peer-kritische massa; boven 20 verdwijnt individuele interactie).
+- **Cadans**: wekelijks ritme werkt voor professionals; elke twee weken haalbaar; minder frequent dan dat → accountability verdampt.
+- **Inhoud live**: géén theorieverhaal — dat is flipped verspilling. Wél: toepassen, debatteren, casus oplossen, peer review, AMA, rolspel met AI-guardrails.
+
+## Ondersteuning zelfstudie — afhaakpreventie
+
+Completion-rates van MOOCs (5–15%) zijn een waarschuwing. Wat helpt:
+
+- **Kleine cohorten** met gezichten (sociale druk).
+- **Gating**: toegang tot volgende module pas na check-in of korte quiz (retrieval practice fungeert ook als gate).
+- **Nudges**: 1 korte reminder per week, persoonlijk waar kan.
+- **AI-bot met volledige cursuscontext**: voor "24/7 stuck-fixer". Voorkomt dropout bij het moment waar de meeste mensen afhaken: frustratie bij toepassing. **Belangrijk**: bot moet *Socratisch* reageren (terugvragen), niet klakkeloos antwoord geven — anders wordt het de nieuwe shortcut en verdwijnt retrieval practice.
+- **Zichtbare voortgang** (maar niet gamification for its own sake).
+
+## Pilot & iteratie
+
+### Kleine cohort eerst: 10 → 50
+
+Best practice uit eLearning Industry en ProductLed framework:
+
+- **Pilot van ~10 deelnemers** is de sweet spot: genoeg signaal, snel te faciliteren, hoge feedback-diepte. Bij 5 mis je variatie; bij 25 verdrinkt het in ruis.
+- **Bij voorkeur gemengd**: verschillende sectoren/rollen, om PMF breder te testen.
+- **Gratis of sterk gereduceerd tarief, in ruil voor feedbackverplichting** (diepte-interview na elke module).
+
+### Meten: Kirkpatrick, met nuance
+
+Kirkpatrick's 4 niveaus:
+
+1. **Reaction** — tevredenheid (NPS, CSAT).
+2. **Learning** — wat weten/kunnen ze nu? (pre/post assessment, retrieval).
+3. **Behavior** — wat doen ze anders op hun werk? (3–6 maanden later).
+4. **Results** — meetbare business-impact.
+
+**Belangrijke kritieken (Kirkpatrick Partners erkent dit zelf; 2024-updates Alzate):**
+
+- Niveau 1 (reaction) correleert zwak met daadwerkelijke performance. "Ze vonden het leuk" ≠ "ze leren beter" ≠ "ze doen het beter". Voorbeeld: entertainerige trainers scoren hoger op reaction, maar niet op learning.
+- Niveau 3 en 4 zijn vaak buiten het bereik van de opleider (organisatiecontext).
+
+### Praktisch meet-framework voor BeeHaive pilot
+
+| Niveau | Meetinstrument | Wanneer | Target |
+|---|---|---|---|
+| 1 | NPS + 3 open vragen ("wat werkt / wat mist / wat snijden") | Na elke module + eind | NPS ≥ 30 is oké, ≥ 50 = goed |
+| 2 | Retrieval-quizzes per bouwsteen + eindopdracht (eigen project) | Continu + eind | Quiz-gemiddelde > 70%; project beoordeeld met rubric |
+| 3 | Zelfrapportage + korte case-interview 3 mnd later | 3 maanden na afsluiting | Kwalitatief; ≥ 60% geeft concreet voorbeeld van toepassing |
+| 4 | (Optioneel, organisatiegebonden; alleen bij in-company) | 6 mnd | Case-per-case |
+
+### Iteratie-ritme
+
+- Na elke module: 30-min retro met 2–3 deelnemers.
+- Na afloop pilot: volledige decompositie per bouwsteen — wat snijden, wat verlengen, wat van modaliteit wisselen.
+- **PMF-signaal** (productled framework): cohort-retentie voor vervolgmodules, en de "Sean Ellis vraag" — *"Hoe teleurgesteld zou je zijn als BeeHaive niet meer bestond?"*. Target: >40% zegt "heel teleurgesteld" → PMF.
+- Van pilot naar 50+: herhaal eerst met cohort 2 (~15 deelnemers) met aanpassingen vóór je naar 50 schaalt. Prematuur schalen is de meest voorkomende fout.
+
+## Bronnen
+
+**Blended, flipped, cohort-based**
+
+- [Flipped classroom second-order meta-analysis — Sciencedirect (2025)](https://www.sciencedirect.com/science/article/abs/pii/S0883035525003283)
+- [Online/blended/flipped meta-analysis — Sciencedirect (2023)](https://www.sciencedirect.com/science/article/pii/S2666557323000204)
+- [Blended vs online — PMC (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC12467614/)
+- [MOOC Completion rates — Open Praxis (2024)](https://openpraxis.org/articles/10.55982/openpraxis.16.3.606)
+- [a16z / Maven — Cohorts are King](https://maven.com/resources/a16z-cohorts-are-king)
+- [Best Cohort Based Platforms (2026) — Educate Me](https://www.educate-me.co/blog/best-cohort-based-learning-platforms)
+- [Synchronous Online Sessions — Boston College CTE](https://cteresources.bc.edu/documentation/synchronous-teaching-considerations/teaching-an-online-synchronous-session/)
+- [Disco: Psychology of Cohort Learning (2026)](https://www.disco.co/blog/the-psychology-of-cohort-learning-key-insights-for-2026)
+
+**Kirkpatrick & pilot/PMF**
+
+- [Kirkpatrick Partners — The Kirkpatrick Model](https://www.kirkpatrickpartners.com/the-kirkpatrick-model/)
+- [Kirkpatrick Model — Valamis](https://www.valamis.com/hub/kirkpatrick-model)
+- [Adaptation of Kirkpatrick's 4-Level Model — ERIC](https://files.eric.ed.gov/fulltext/EJ1290265.pdf)
+- [Framework for Driving PMF Through Pilots — ProductLed](https://www.productled.org/blog/framework-driving-product-market-fit-pilots)
+- [Pilot Your Online Course — eLearning Industry](https://elearningindustry.com/pilot-your-online-course-things-consider)

--- a/docs/research/training-design-2026-04/04-retentie-memory.md
+++ b/docs/research/training-design-2026-04/04-retentie-memory.md
@@ -1,0 +1,101 @@
+# 04 — Retentie: kennis naar lange-termijn geheugen
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Spaced repetition (Ebbinghaus, Cepeda, Anki/Leitner)
+
+**Kernbevinding.** De meta-analyse van Cepeda et al. (839 assessments over 317 experimenten) toont onomstotelijk aan dat gespreide (spaced) studie beter werkt dan gemasseerd (massed). De vuistregel uit Cepeda et al. (2008): het optimale interval tussen herhalingen bedraagt ongeveer **10–20% van de gewenste retentietermijn**. Wil je een concept 6 maanden laten zitten, herhaal het dan na ~3–4 weken. Wil je het 1 jaar laten zitten, dan is een interval van ~5–10% (~3–5 weken) optimaal.
+
+Het Leitner-systeem (1970) en Anki's SM-2 algoritme zijn praktische implementaties: kaarten die correct worden beantwoord verhuizen naar langere intervallen (1d → 3d → 7d → 16d → 35d …); foute kaarten vallen terug naar interval 1. Anki-gebruikers scoren 5–10 punten hoger op examens zoals USMLE Step 1 (correlationeel, niet strikt causaal). Claims dat spaced repetition retentie "met 200%" verhoogt zijn marketing-achtig; de peer-reviewed literatuur spreekt van medium-tot-grote effect sizes.
+
+**Toepassing voor BeeHaive.**
+
+- Bouw per bouwsteen en per guardrail een micro-deck van 8–15 flashcards (definitie, voorbeeld, tegenvoorbeeld, toepassingsvraag).
+- Implementeer een Leitner-achtige flow in de cursusbot: dag 1, 3, 7, 16, 35, 90 voor de kern-concepten. De AI-bot kan kaarten semi-automatisch genereren uit cursusnotities met RAG-grounding.
+- Communiceer expliciet naar cursisten dat "even elke dag 5 minuten" effectiever is dan een uur per week.
+
+**Evidence-sterkte.** Zeer sterk (meta-analytisch, decennia onderzoek).
+
+## Retrieval practice / testing effect (Roediger & Karpicke)
+
+**Kernbevinding.** Roediger & Karpicke (2006, 2008) lieten zien dat actief terughalen dramatisch beter is dan herlezen. Rowland (2014) vond een medium-to-large effect (g = 0.50) in meta-analyse. Belangrijk: zónder feedback werkt het testing effect alleen als praktijktest-accuracy **>50%** is — anders versterk je fouten. "Testing is leren, niet meten" is de kernboodschap.
+
+**Toepassing voor BeeHaive.**
+
+- Elke module eindigt niet met "samenvatting" maar met 3–5 vrije-ophaalvragen ("Beschrijf in eigen woorden waarom guardrail X de risico's van bouwsteen Y afdekt").
+- De cursusbot stelt spontane terugblikvragen: "Je hebt 2 dagen geleden bouwsteen 3 gedaan — kun je zonder terug te kijken de drie kernvragen formuleren die een governance-owner moet stellen?"
+- Lage-stakes quizzes wekelijks (geen cijfer), met directe feedback.
+
+**Evidence-sterkte.** Zeer sterk.
+
+## Interleaving vs. blocked practice (Rohrer)
+
+**Kernbevinding.** Rohrer & Taylor (2010): leerlingen die rekenproblemen door elkaar (interleaved) oefenden scoorden na 1 dag 77% vs. 38% voor blocked practice. Het mechanisme: discriminatief contrast — je moet wáárnemen welk concept van toepassing is. **Nuance uit 2025-onderzoek** (MDPI *Behavioral Sciences*): als het doel is een *regel* te leren, is blocked soms beter; voor *herkenning van categorieën op basis van similariteit* is interleaving beter.
+
+**Toepassing voor BeeHaive.**
+
+- Na blok-introductie van bouwstenen 1–7 (blocked), volgt een interleaved oefenblok waarin casussen door elkaar komen: "Welke bouwsteen is hier het meest relevant? Welke guardrail?"
+- In de bot: praktijkcasussen uit verschillende sectoren (zorg, overheid, retail) die door elkaar worden aangeboden, niet per sector gegroepeerd.
+
+**Evidence-sterkte.** Sterk voor categorie-discriminatie; gemengd voor regelgebaseerde taken.
+
+## Elaboration
+
+**Kernbevinding.** Dunlosky et al. (2013) gaf elaboratieve interrogatie en self-explanation een *moderate* utility rating — positief, maar minder robuust dan spacing en retrieval. Elaboratie werkt het best wanneer cursisten nieuwe informatie koppelen aan **eigen werkcontext**.
+
+**Toepassing voor BeeHaive.**
+
+- Elke module bevat de vraag: "Geef een voorbeeld uit je eigen organisatie waar deze bouwsteen/guardrail wel/niet wordt toegepast." De AI-bot kan meedenken en doorvragen.
+- "Waarom"-vragen na elk concept: niet "wat is bouwsteen 4" maar "waarom is bouwsteen 4 nodig in een organisatie zonder model governance?"
+
+**Evidence-sterkte.** Matig-sterk.
+
+## Dual coding (kort)
+
+**Kernbevinding.** Combinatie van verbale en visuele representaties verbetert retentie (Paivio, later Mayer's multimedia principles). Dunlosky's review: veelbelovend maar afhankelijk van kwaliteit van visuals. Volledig uitgewerkt in deelbestand 02.
+
+**Toepassing voor BeeHaive.**
+
+- Eén consistente infographic per bouwsteen/guardrail (visueel ankerpunt).
+- Framework-diagram waarin alle 7+7 in relatie staan — cursisten zien dit steeds terug.
+
+**Evidence-sterkte.** Matig-sterk.
+
+## Vertaling naar 4–8 weken training + follow-up
+
+**Concrete blueprint voor BeeHaive:**
+
+- **Week 1–4:** één bouwsteen per week (live + self-paced). Elke week: video, lezing, 3 flashcards per concept, 1 live Q&A.
+- **Week 5–8:** guardrails geïntroduceerd, interleaved met de bouwstenen.
+- **Review-cyclus in de bot:** dag 1 (direct), dag 3, dag 7, dag 21, dag 60, dag 120 per concept.
+- **Capstone:** cursisten schrijven een mini-governance-plan voor hun eigen organisatie (elaboration + transfer).
+
+## Bronnen
+
+**Spaced repetition & forgetting curve**
+
+- [Cepeda et al. (2008) Spacing effects in learning — PubMed](https://pubmed.ncbi.nlm.nih.gov/19076480/)
+- [Cepeda et al. (2006) Distributed practice meta-analysis — PDF](https://augmentingcognition.com/assets/Cepeda2006.pdf)
+- [Using Spacing to Enhance Diverse Forms of Learning (ERIC)](https://files.eric.ed.gov/fulltext/ED536925.pdf)
+- [Spaced Repetition — Wikipedia](https://en.wikipedia.org/wiki/Spaced_repetition)
+- [Anki SRS Algorithm (Sobczak)](https://juliensobczak.com/inspect/2022/05/30/anki-srs/)
+- [Leitner System Guide — e-student](https://e-student.org/leitner-system/)
+
+**Retrieval practice / testing effect**
+
+- [Roediger & Karpicke (2006) The Power of Testing Memory](http://psychnet.wustl.edu/memory/wp-content/uploads/2018/04/Roediger-Karpicke-2006_PPS.pdf)
+- [Karpicke & Roediger (2008) Repeated retrieval — PDF](https://learninglab.psych.purdue.edu/downloads/2007/2007_Karpicke_Roediger_JML.pdf)
+- [Retrieval-Based Learning: A Decade of Progress (ERIC)](https://files.eric.ed.gov/fulltext/ED599273.pdf)
+- [Mike Taylor (2025) The Testing Effect](https://mike-taylor.org/2025/12/01/the-testing-effect-why-retrieval-practice-is-your-most-powerful-learning-tool/)
+- [Cross-disciplinary replication — PMC (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC12302331/)
+
+**Interleaving**
+
+- [Whether Interleaving or Blocking Is More Effective (MDPI 2025)](https://www.mdpi.com/2076-328X/15/5/662)
+- [Rohrer — Interleaved Practice Improves Mathematics Learning (ERIC)](https://files.eric.ed.gov/fulltext/ED557355.pdf)
+- [Firth (2021) Systematic review of interleaving — Wiley](https://bera-journals.onlinelibrary.wiley.com/doi/10.1002/rev3.3266)
+
+**Elaboration / Dunlosky**
+
+- [Dunlosky et al. (2013) Improving Students' Learning — PDF](https://www.whz.de/fileadmin/lehre/hochschuldidaktik/docs/dunloskiimprovingstudentlearning.pdf)
+- [A Meta-Analysis of Ten Learning Techniques — Frontiers](https://www.frontiersin.org/journals/education/articles/10.3389/feduc.2021.581216/full)

--- a/docs/research/training-design-2026-04/05-retentie-postcourse.md
+++ b/docs/research/training-design-2026-04/05-retentie-postcourse.md
@@ -1,0 +1,93 @@
+# 05 — Retentie: post-course mechanismen
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Drip-emails / nurture sequences
+
+**Kernbevinding.** >70% van cursisten van betaalde cursussen haakt af binnen 2 weken (LearnWorlds, Learning Revolution 2025). Effectieve cadans: 1–2 emails per week, verbonden aan mijlpalen, niet aan kalender. De "Forgetting Curve"-literatuur (Ebbinghaus) onderbouwt waarom een drip-schedule werkt: reactivatie vóór vergetingsdip.
+
+**Aanbevolen cadans voor BeeHaive (post-course):**
+
+| Dag | Inhoud | Lengte |
+|---|---|---|
+| 1 | "Waar begin je? 3 acties deze week" + 1 flashcard | ~200 woorden |
+| 3 | Retrieval-quiz (1 open vraag, antwoord pas bij klik zichtbaar) | zeer kort |
+| 7 | Case study uit de praktijk, gelinkt aan bouwsteen 1 | 400 woorden |
+| 14 | Implementation intention prompt: "Welk moment in je week ga je guardrail X toepassen?" | 100 woorden + form |
+| 30 | Booster quiz (5 vragen) + link naar community | 5 min |
+| 60 | Nieuwe case + reflectievraag | 400 woorden |
+| 90 | Zelfassessment: wat pas je daadwerkelijk toe? | survey |
+
+**Evidence-sterkte.** Middel — sterke theoretische basis (spacing, testing effect), maar specifieke email-cadans is grotendeels marketing-literatuur, niet RCT's.
+
+## Booster sessions / follow-up meetings
+
+**Kernbevinding.** Transfer E-Booster onderzoek (Hawaii): deelnemers met online booster-interventies scoorden significant hoger op knowledge retention. BizLibrary: zonder booster vergeet men ~70% binnen 24 uur.
+
+**Aanbeveling voor BeeHaive:**
+
+- **Maand 1 booster:** 60-minuten live online sessie, 10–15 deelnemers, format: elk 3 minuten over "wat heb ik toegepast, waar loop ik tegenaan", collectieve probleemoplossing.
+- **Maand 3 booster:** 90-minuten sessie, diepere casuïstiek, eventueel gasten (ervaringsdeskundigen).
+- **Optioneel maand 6:** alumni-event.
+
+**Evidence-sterkte.** Middel-sterk (kleinere studies, maar consistent richtingeffect).
+
+## Community / peer-learning
+
+**Kernbevinding.** Meta-analyse (APA 2021): peer interaction heeft een significant positief effect op leren, gemiddeld medium effect size. Mechanisme: peer instruction triggert retrieval en diepe verwerking. De "Learning Pyramid" (90% door te onderwijzen) is bekend maar **niet** empirisch onderbouwd — schrap die claim uit marketing, maar het onderliggende principe (teaching others = retrieval + elaboration) is wel solide.
+
+**Toepassing voor BeeHaive.**
+
+- Besloten community (Slack/Discord/Circle) per cohort.
+- "Guardrail-van-de-maand": één alumni facilitator leidt discussie.
+- AI-bot leest mee (met consent) en signaleert herhaal-vragen → kan FAQ voeden.
+
+**Evidence-sterkte.** Sterk principe, matige evidence voor specifieke online-format ROI.
+
+## Blog / newsletter als herhaalkanaal
+
+**Kernbevinding.** Lange-termijn engagement via nieuwe content is *spaced exposure* + *elaboration*. Minder direct bewijs voor retentie, maar de mechanismen zijn dezelfde als drip-emails.
+
+**Toepassing voor BeeHaive.**
+
+- Maandelijkse nieuwsbrief met 1 case study, 1 tool-update, 1 vraag uit de community.
+- Blogs per bouwsteen/guardrail gelinkt vanuit drip-mails en bot-antwoorden.
+
+## Implementation intentions (Gollwitzer)
+
+**Kernbevinding.** Gollwitzer & Sheeran's meta-analyse (94 studies): "if-then plans" leveren medium-to-large effect (d = 0.65) op doelrealisatie. Vorm: "Als [situatie X], dan doe ik [gedrag Y]."
+
+**Toepassing voor BeeHaive.**
+
+- Aan het einde van elke module een if-then prompt:
+  - "Als een collega voorstelt om een LLM in productie te zetten zonder evaluatie, dan stel ik guardrail 3 voor."
+- Deze zinnen worden in de bot opgeslagen; de bot herinnert eraan bij dag-14 en dag-60 check-ins.
+
+**Evidence-sterkte.** Zeer sterk.
+
+## Bronnen
+
+**Drip emails / post-course retention**
+
+- [Midlands in Business — Email Nurture Sequences for Course Participants](https://midlandsinbusiness.com/email-nurture-sequences-for-course-participants-to-improve-retention)
+- [LearnWorlds (2026) Email Sequences for Online Courses](https://www.learnworlds.com/email-sequences-launch-online-course-examples/)
+- [Learning Revolution (2025) Email Sequences](https://www.learningrevolution.net/email-sequences/)
+- [LMS Portals — Drip Email Campaign](https://www.lmsportals.com/post/why-every-training-company-needs-a-drip-email-campaign)
+
+**Booster sessions / training transfer**
+
+- [Transfer E-Booster Study — ScholarSpace Hawaii](https://scholarspace.manoa.hawaii.edu/items/829eb885-9603-4c2c-9af3-7a7ef1757a80)
+- [BizLibrary — Learning Retention](https://www.bizlibrary.com/blog/learning-methods/learning-retention-key-employee-training/)
+- [BizLibrary — Post-Training Reinforcement](https://www.bizlibrary.com/blog/learning-methods/post-training-reinforcement-for-employees/)
+- [Learning and transfer in organisations (Tandfonline 2025)](https://www.tandfonline.com/doi/full/10.1080/1359432X.2025.2463799)
+
+**Peer learning / community**
+
+- [How Effective Is Peer Interaction (APA meta-analysis)](https://www.apa.org/pubs/journals/features/edu-edu0000436.pdf)
+- [Peer Assisted Learning scoping review — PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC11653801/)
+- [Why does peer instruction benefit student learning — Springer](https://link.springer.com/article/10.1186/s41235-020-00218-5)
+
+**Implementation intentions**
+
+- [Gollwitzer & Sheeran (2006) Meta-analysis — ResearchGate](https://www.researchgate.net/publication/37367696_Implementation_Intentions_and_Goal_Achievement_A_Meta-Analysis_of_Effects_and_Processes)
+- [Gollwitzer & Oettingen (2019) Implementation Intentions](https://www.psy.uni-hamburg.de/arbeitsbereiche/paedagogische-psychologie-und-motivation/personen/oettingen-gabriele/dokumente/gollwitzer-oettingen-2019-implementation-intentions.pdf)

--- a/docs/research/training-design-2026-04/06-ai-tutor.md
+++ b/docs/research/training-design-2026-04/06-ai-tutor.md
@@ -1,0 +1,196 @@
+# 06 — AI-tutor: design, guardrails, privacy & meting
+
+> Onderdeel van het training-design onderzoek (april 2026). Zie [`INDEX.md`](INDEX.md).
+
+## Effectiviteit van AI-tutors — wat we weten (2023–2026)
+
+**Gemengd beeld.**
+
+- **Khanmigo:** mixed-methods studie (69 undergrad physics students, *Journal of Teaching and Learning*, 2025): significante learning gains in álle condities, maar géén significant verschil tussen Khanmigo en Google. Studenten waardeerden wel de step-by-step guidance. J-PAL doet een grotere efficacy-studie.
+- **Harvard CS50 Duck (Malan, Liu et al., SIGCSE 2024):** grootschalige deployment, sterk positieve student feedback ("alsof ik een persoonlijke TA heb"). Geen RCT; vooral kwalitatief.
+- **Duolingo Max:** interne data claimen 34% betere grammatica-retentie met "Explain My Answer" en 15% hogere course completion. Bedrijfsdata, niet peer-reviewed, dus met voorbehoud.
+- **Rori (Ghana, WhatsApp math tutor):** 1 uur/week → effect size equivalent aan een extra schooljaar. Eén van de sterkste effect sizes in AI-tutor literatuur (wél peer-reviewed RCT).
+
+**Tegenbewijs/waarschuwingen.**
+
+- University of Pennsylvania studie (Turkse high school, 2024): ChatGPT-gebruikers losten 48% meer oefenproblemen correct op, maar scoorden 17% lager op een conceptueel begrip-test. Cognitive offloading waarschuwing.
+- MDPI & *Frontiers in Psychology* (2025): frequent AI-gebruik correleert negatief met critical thinking, gemedieerd door cognitive offloading, vooral bij jongeren.
+
+**Eerlijke inschatting.** AI-tutors zijn *geen* wondermiddel; ze zijn vooral effectief als *scaffolding*-tool die actief denkwerk uitlokt, niet als antwoord-leverancier.
+
+## RAG over cursusmateriaal — grounding
+
+**Kernprincipes (uit 2025 reviews, MEGA-RAG, MetaRAG):**
+
+- **Grounding = antwoorden verankeren aan verifieerbare documenten.** Zonder grounding hallucineren LLM's.
+- **Citaties per claim:** elk feitelijk statement moet verwijzen naar een cursusbron (module, pagina, video-timestamp).
+- **"Weet ik niet"-gedrag:** de bot moet expliciet zeggen wanneer retrieval niets relevants oplevert; gebruik een confidence threshold.
+- **Dual-pathway retrieval** (dense + sparse + knowledge graph): KG-RAG reduceerde hallucinaties met 18% in biomedical QA. Past goed bij BeeHaive's Neo4j knowledge graph.
+
+**Toepassing voor BeeHaive.**
+
+- Alle cursuscontent (video-transcripts, slides, MDX-content in `frontend/src/content`, Neo4j-knowledge-graph van het framework) ingesten in vector store + KG.
+- **System prompt patroon:**
+  - "Antwoord alléén op basis van de opgehaalde cursusfragmenten. Citeer altijd module en sectie. Als de fragmenten geen antwoord bieden, zeg: 'Dit valt buiten de cursusinhoud — ik raad je aan vraag X te stellen aan een moderator.'"
+- **Evaluation:** metamorphic testing (MetaRAG-stijl): decompose antwoorden in atomic factoids, verifieer tegen retrieved context.
+
+**Evidence-sterkte.** Sterk en snel evoluerend.
+
+## Scaffolding via AI — Socratische prompting
+
+**Kernbevinding.** Structurele prompts ("clarify → justify → counterexample → synthesize") + de regel "*Never give the student the answer*" in de system prompt produceren meetbaar meer zelf-reflectie en kritisch denken (SPL / Socratic Playground for Learning; Evolutionary RL Socratic tutor: critical thinking frequency ~3× hoger dan supervised fine-tuning baseline).
+
+**System-prompt template voor BeeHaive-bot (RTRI framework):**
+
+- **Role:** "Je bent een Socratische tutor voor BeeHaive's AI-governance cursus."
+- **Task:** "Help de cursist concepten te begrijpen door vragen te stellen, geen directe antwoorden."
+- **Requirements:** "Geef nooit een volledig antwoord bij een open-eind vraag. Begin met een verhelderende tegen-vraag. Geef hints in 3 niveaus: (1) context, (2) gerelateerd concept, (3) gedeeltelijke hint. Pas na 3 pogingen van cursist mag je een fragment van het antwoord geven."
+- **Instructions:** "Blijf binnen de 7 bouwstenen + 7 guardrails. Citeer bron bij elke feitelijke claim. Als cursist vraagt om 'de casus voor me op te lossen', weiger vriendelijk en bied scaffolding aan."
+
+## Guardrails — implementatie
+
+**Best-practice patronen (2025 literatuur, Arthur AI, Confident AI, Datadog):**
+
+- **Pre-LLM guardrails:** input-filtering. Blokkeer: verzoeken om volledige essays/huiswerk op te lossen, vragen buiten scope (politiek, andere frameworks).
+- **Post-LLM guardrails:** output-filtering. Check: bevat antwoord citaat? Is antwoord >X tokens zonder scaffolding-vraag? Bevat het PII?
+- **LLM-as-judge evaluatie:** tweede model beoordeelt of antwoord Socratisch is (heeft vraag, geeft niet te veel weg) en grounded.
+- **Domain boundary:** expliciete lijst van in-scope topics (de 7+7) en een "escalatie naar moderator"-pad.
+
+**Concreet voor BeeHaive:**
+
+- Guardrails-AI library (Python) in `backend/app/services`; policy definities als YAML.
+- Logging van alle guardrail-triggers voor review.
+
+## Voorkomen van luiheid / cognitive offloading
+
+**Kernbevinding.** Over-reliance op AI verlaagt concept-begrip (UPenn studie, 17% lager). Mitigaties uit literatuur:
+
+- **Reflection prompts:** "Leg het antwoord in eigen woorden uit" na bot-interactie.
+- **AI-free sessies:** zelf-tests zonder botgebruik (zichtbaar gelogd).
+- **Delayed testing:** quiz op dag 7 over concepten die op dag 1 met de bot waren besproken — zonder botgebruik.
+- **Transparantie over gebruik:** cursisten zien hun eigen "bot-dependency score" als zachte nudge.
+
+## Privacy — AVG-conform
+
+**Kernbevindingen (2025–2026 guides: moinAI, DocuChat, Premai, Quickchat):**
+
+- **EU-hosting verplicht** voor gevoelige conversaties — BeeHaive zit al goed met Hetzner.
+- **Data-minimalisatie:** bewaar chat-logs zo kort mogelijk (default: 30–90 dagen; 1 jaar is al lang).
+- **Recht op vergeten:** expliciete delete-functie per gebruiker.
+- **Geïnformeerde consent:** duidelijk tonen dat cursist met AI chat, wat wordt opgeslagen, waarvoor gebruikt.
+- **DPIA verplicht** voor AI-systemen die persoonsgegevens verwerken (EU AI Act + AVG overlap).
+- **Encryptie in transit & at rest** voor alle conversation-data.
+- **Geen gebruik van cursist-data voor LLM-training** zonder aparte opt-in.
+- **Processor agreements** met LLM-provider (Anthropic): zero-data-retention endpoints aanvragen waar mogelijk.
+
+**Concreet voor BeeHaive:**
+
+- Postgres tabel `chat_sessions` met TTL van 90 dagen (configurable per gebruiker).
+- DPIA-document als onderdeel van de governance-documentatie (eet je eigen hondenbrood).
+- In de privacy-policy expliciet: conversaties → alleen gebruikt voor kwaliteitsverbetering, nooit voor training van derde-partij-modellen.
+
+**Evidence-sterkte.** Juridisch vereist, niet optioneel.
+
+## Measurement — retentie & indicatoren
+
+### Hoe meet je retentie concreet?
+
+**Best practice uit Kirkpatrick-literatuur (2025–2026):**
+
+- **Level 1 (Reaction):** direct na module — NPS, relevantie-score.
+- **Level 2 (Learning):** direct + delayed post-tests op **dag 30, 60, 90**. Zelfde item-bank, random sample 10 items.
+- **Level 3 (Behavior):** 30/60/90 dagen, via zelf-rapportage + (waar mogelijk) manager observation. Sweet spot is dag 45–60 voor balans response rate vs. transfer-periode.
+- **Level 4 (Results):** business outcomes — voor BeeHaive lastig, maar proxies: aantal governance-artefacten geproduceerd, incidents voorkomen.
+
+**Waarschuwing:** response rates dalen van ~80% (direct) naar 20–40% (delayed). Gebruik:
+
+- Korte surveys (5 min max).
+- Incentives (bijv. een additional resource na invullen).
+- De AI-bot kan het als conversationeel formulier aanbieden — hogere response rates.
+
+### Leading vs. lagging indicators
+
+| Type | Indicator |
+|---|---|
+| Leading | % cursisten dat binnen 30 dagen een governance-document heeft opgesteld |
+| Leading | Aantal if-then plans dat is uitgevoerd (zelfrapportage) |
+| Leading | Bot-engagement frequency (als proxy voor actieve verwerking — let op offloading-risico) |
+| Leading | Community-posts per cursist |
+| Leading | Delayed quiz-score dag 60 |
+| Lagging | Adoptie van BeeHaive-framework in de organisatie (jaarlijkse survey alumni) |
+| Lagging | Door cursisten gerapporteerde AI-incidenten voorkomen |
+| Lagging | NPS/retention voor vervolgcursussen |
+
+**Evidence-sterkte.** Framework is standaard (Kirkpatrick sinds 1959, herzien in "New World" model 2016); specifieke metrieken voor AI-governance training zijn nieuw en moeten bij BeeHaive zelf gevalideerd worden.
+
+## Slotsamenvatting — 7 prioriteiten voor BeeHaive-design
+
+1. **Spaced retrieval als ruggegraat** (zeer sterke evidence): Leitner-achtige flashcard-flow in bot op dag 1, 3, 7, 21, 60, 120.
+2. **Testing ≠ meten; testing = leren.** Elke module eindigt met 3–5 open retrieval-vragen.
+3. **Interleaved cases in weken 5–8**, blocked introductie in weken 1–4.
+4. **If-then implementation intentions** aan het eind van elke module (d = 0.65).
+5. **Socratische AI-bot met RAG + strikte guardrails**, expliciet "never give the answer", citaties verplicht.
+6. **Post-course drip:** dag 1, 3, 7, 14, 30, 60, 90 + booster-sessies op maand 1 en 3.
+7. **Delayed post-tests op 30/60/90 dagen** + leading indicators (governance-artefacten, if-then completion) + jaarlijkse alumni-survey voor lagging indicators.
+
+**Waar de evidence zwak is:** exacte email-cadans, effect sizes van community-learning in online B2B-context, en lange-termijn effectiviteit van AI-tutors voor volwassen professionals (meeste studies zijn K-12 of undergraduate). BeeHaive zou een eigen A/B-test moeten inbouwen (bot-aan vs. bot-uit groep) om hierover zelf data te genereren.
+
+## Bronnen
+
+**AI-tutors: Khanmigo, CS50, Duolingo**
+
+- [Khanmigo — Journal of Teaching and Learning (2025)](https://jtl.uwindsor.ca/index.php/jtl/article/view/10052)
+- [J-PAL — AI-Powered Tutoring Khanmigo](https://www.povertyactionlab.org/initiative-project/ai-powered-tutoring-unleashing-full-potential-personalized-learning-khanmigo)
+- [Khan Academy Efficacy Results November 2024](https://blog.khanacademy.org/khan-academy-efficacy-results-november-2024/)
+- [Liu et al. — Teaching CS50 with AI (SIGCSE 2024)](https://cs.harvard.edu/malan/publications/V1fp0567-liu.pdf)
+- [Improving AI in CS50 — Liu et al.](https://cs.harvard.edu/malan/publications/fp0627-liu.pdf)
+- [Harvard SEAS — Quacking into Computer Programming](https://seas.harvard.edu/news/2024/01/quacking-computer-programming)
+- [Duolingo Max Review 2025 — Medium](https://cheapersgames.medium.com/duolingo-max-review-how-ai-makes-language-learning-2-faster-in-2025-64fafe992424)
+- [5D Vision — Duolingo AI Case Study](https://www.5dvision.com/post/case-study-duolingos-ai-powered-language-learning-revolution/)
+
+**RAG, grounding, hallucination mitigation**
+
+- [MEGA-RAG — PMC 2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12540348/)
+- [RAG Comprehensive Survey — arxiv 2506.00054](https://arxiv.org/html/2506.00054v1)
+- [MetaRAG — CEUR-WS](https://ceur-ws.org/Vol-4136/iaai6.pdf)
+- [Hallucination Mitigation Survey — arxiv 2510.24476](https://arxiv.org/html/2510.24476v1)
+- [RAG in 2025 — Morphik](https://www.morphik.ai/blog/retrieval-augmented-generation-strategies)
+
+**Socratic tutoring & scaffolding**
+
+- [AI Virtual Tutor — U Toronto CTSI (Dec 2025)](https://teaching.utoronto.ca/wp-content/uploads/AI-virtual-tutor-developing-effective-system-prompt-CTSI-Dec2025.pdf)
+- [Evolutionary RL-based Socratic AI Tutor — arxiv 2512.11930](https://arxiv.org/html/2512.11930)
+- [Scaffolding Metacognition in Programming — arxiv 2511.04144](https://arxiv.org/html/2511.04144)
+- [Socratic method AI in healthcare — ScienceDirect](https://www.sciencedirect.com/science/article/pii/S1471595326000727)
+
+**Guardrails for LLM tutors**
+
+- [Arthur AI — Agent Guardrails Best Practices](https://www.arthur.ai/blog/best-practices-for-building-agents-guardrails)
+- [Confident AI — LLM Guardrails Guide](https://www.confident-ai.com/blog/llm-guardrails-the-ultimate-guide-to-safeguard-llm-systems)
+- [Orq.ai — Mastering LLM Guardrails 2025](https://orq.ai/blog/llm-guardrails)
+- [Datadog — LLM Guardrails Best Practices](https://www.datadoghq.com/blog/llm-guardrails-best-practices/)
+- [Guardrails-AI — GitHub](https://github.com/guardrails-ai/guardrails)
+
+**Cognitive offloading / over-reliance**
+
+- [Cognitive paradox of AI in education — PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC12036037/)
+- [AI Tools and Cognitive Offloading — MDPI](https://www.mdpi.com/2075-4698/15/1/6)
+- [Impact of AI Tools on Learning Outcomes — arxiv 2510.16019](https://arxiv.org/html/2510.16019v1)
+- [ChatGPT as cognitive crutch (RCT) — ScienceDirect](https://www.sciencedirect.com/science/article/pii/S2590291125010186)
+- [Learners' AI dependence and critical thinking — ScienceDirect 2025](https://www.sciencedirect.com/science/article/pii/S0001691825010388)
+
+**Privacy / GDPR / AVG**
+
+- [moinAI — Chatbots & data protection 2026](https://www.moin.ai/en/chatbot-wiki/chatbots-data-protection-gdpr)
+- [Premai — GDPR Compliant AI Chat 2026](https://blog.premai.io/gdpr-compliant-ai-chat-requirements-architecture-setup-2026/)
+- [Quickchat — GDPR-Compliant Chatbot Guide 2026](https://quickchat.ai/post/gdpr-compliant-chatbot-guide)
+- [Ninjaibot — GDPR and EU AI Act](https://www.ninjaibot.com/ensuring-ai-chatbot-compliance-with-gdpr-and-the-eu-ai-act/)
+- [Crescendo — AI and GDPR in 2026](https://www.crescendo.ai/blog/ai-and-gdpr)
+
+**Kirkpatrick / measurement**
+
+- [Kirkpatrick Partners — The Kirkpatrick Model](https://www.kirkpatrickpartners.com/the-kirkpatrick-model/)
+- [Knowlify — Kirkpatrick Model Training Evaluation](https://www.knowlify.com/articles/kirkpatrick-model-training-evaluation)
+- [Valamis — Kirkpatrick Model](https://www.valamis.com/hub/kirkpatrick-model)
+- [AllenComm — Corporate Training Metrics (Mar 2026)](https://www.allencomm.com/2026/03/corporate-training-metrics-what-to-track-beyond-completions/)
+- [OpenFormations — Immediate and delayed training evaluations](https://openformations.com/en/blog/evaluations-chaud-froid-formation-guide)

--- a/docs/research/training-design-2026-04/INDEX.md
+++ b/docs/research/training-design-2026-04/INDEX.md
@@ -1,0 +1,19 @@
+# Training Design Research — april 2026
+
+Onderzoek voor het ontwerp van BeeHaive-trainingen. Twee parallelle rapporten, elk gesplitst in 3 thematische delen.
+
+## Rapport 1 — Didactiek & multimodaal leren
+
+- [`01-didactiek-pbl.md`](01-didactiek-pbl.md) — Project-based learning, andragogiek (Knowles), scaffolding, peer review, theorie:praktijk verhouding.
+- [`02-didactiek-multimodaal.md`](02-didactiek-multimodaal.md) — Eerlijk over VAK als neuromyth; dual coding (Paivio), Mayer's 12 multimediaprincipes; materialenmix (long-form, flashcards, podcast, infographic, video).
+- [`03-didactiek-blended-pilot.md`](03-didactiek-blended-pilot.md) — Flipped classroom, cohort-based vs self-paced, synchrone-sessie richtlijnen, pilot-aanpak, Kirkpatrick.
+
+## Rapport 2 — Retentie & AI-tutor
+
+- [`04-retentie-memory.md`](04-retentie-memory.md) — Spaced repetition (Cepeda-intervallen), retrieval practice (Roediger & Karpicke), interleaving, elaboration, dual coding, vertaling naar 4-8 weken curriculum.
+- [`05-retentie-postcourse.md`](05-retentie-postcourse.md) — Drip-emails (cadans dag 1/3/7/14/30/60/90), booster-sessies, community/peer-learning, blog/newsletter, implementation intentions (Gollwitzer).
+- [`06-ai-tutor.md`](06-ai-tutor.md) — AI-tutor effectiviteit (Khanmigo, CS50, Duolingo, Rori), RAG-grounding & citations, Socratische scaffolding, guardrails, cognitive offloading, AVG/privacy, Kirkpatrick-meting.
+
+## Status
+
+Onderzoeksinput voor het later op te stellen `docs/plans/TRAINING-DESIGN.md`. Beide rapporten zijn evidence-based en eerlijk over waar de evidence sterk of zwak is.


### PR DESCRIPTION
Twee parallelle onderzoeksrapporten gesplitst in 6 thematische bestanden +
INDEX. Input voor het later op te stellen TRAINING-DESIGN.md.

Rapport 1 — Didactiek & multimodaal leren:
- 01: Project-based learning, andragogiek (Knowles), scaffolding, peer review
- 02: Eerlijk over VAK als neuromyth; dual coding, Mayer's 12 principes;
      materialenmix (long-form, flashcards, podcast, infographic, video)
- 03: Flipped/cohort-based, synchrone richtlijnen, pilot, Kirkpatrick

Rapport 2 — Retentie & AI-tutor:
- 04: Spaced repetition (Cepeda), retrieval practice (Roediger & Karpicke),
      interleaving, elaboration, 4-8 weken curriculum-blueprint
- 05: Drip-cadans dag 1/3/7/14/30/60/90, booster-sessies, community,
      implementation intentions (Gollwitzer)
- 06: AI-tutor effectiviteit, RAG-grounding, Socratische scaffolding,
      guardrails, cognitive offloading, AVG/Hetzner, Kirkpatrick-meting

https://claude.ai/code/session_01SMMv9ejsufc1zb5Shve2f6